### PR TITLE
countParticlesPerBox CUDA Kernel

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,17 @@ For each particle, I call the `apply_force_from_neighbor_gpu` CUDA kernel for ea
 
 The idea is to parallelize counting the number of particles per box, computation of the prefix sum, and assignment of `parts` indices to `particle_ids` through the GPU. Each thread will have access to the shared `gpu_boxCounts`, `gpu_prefixSums`, and `gpu_particle_ids` arrays. Atomic operations for adding in `gpu_boxCounts` will be necessary to prevent race conditions. Specifically, I can use `atomicAdd(int* address, int val)` to add val to the integer array at address `int* address`. Need to explore the best method for computing a prefixSum on the GPU: probably `thrust::exclusive_scan`.
 
+## Debugging Information For GPU countParticlesPerBox
+
+For 1000 particles, 71 boxes by 71 boxes. boxSize1D: 0.01  
+
+cur parts idx: 63. boxIndex: 3638. Coords: (0.177000, 0.519787)
+Row = 51. Col = 17.
+BoxIndex = row * 71 + col = 3638.
+
+Box calculation is correct on the GPU side.
+
+
 ## Useful Commands
 
 salloc -A mp309 -N 1 -C gpu -q interactive -t 00:05:00

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ For each particle, I call the `apply_force_from_neighbor_gpu` CUDA kernel for ea
 
 ## GPU assignToBoxes
 
-The idea is to parallelize counting the number of particles per box, computation of the prefix sum, and assignment of `parts` indices to `particle_ids` through the GPU. Each thread will have access to the shared `gpu_boxCounts`, `gpu_prefixSums`, and `gpu_particle_ids` arrays. Atomic operations for adding in `gpu_boxCounts` will be necessary to prevent race conditions. Need to explore the best method for computing a prefixSum on the GPU: probably `thrust::exclusive_scan`.
+The idea is to parallelize counting the number of particles per box, computation of the prefix sum, and assignment of `parts` indices to `particle_ids` through the GPU. Each thread will have access to the shared `gpu_boxCounts`, `gpu_prefixSums`, and `gpu_particle_ids` arrays. Atomic operations for adding in `gpu_boxCounts` will be necessary to prevent race conditions. Specifically, I can use `atomicAdd(int* address, int val)` to add val to the integer array at address `int* address`. Need to explore the best method for computing a prefixSum on the GPU: probably `thrust::exclusive_scan`.
 
 ## Useful Commands
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ BoxIndex = row * 71 + col = 3638.
 
 Box calculation is correct on the GPU side.
 
+Sum of gpu_boxCounts: 999
+
+For some reason, not all the particles are being assigned to a box initially.
+
+[X] FIXED: atomicAdd ensures all particles are counted and added to boxCounts
+[ ] TODO: correctness check failing
 
 ## Useful Commands
 

--- a/README.md
+++ b/README.md
@@ -18,14 +18,9 @@ In each simulation step, I call the `compute_forces_gpu` CUDA kernel, which assi
 
 For each particle, I call the `apply_force_from_neighbor_gpu` CUDA kernel for each of the neighboring boxes. Currently the calling of this neighbor forces kernel is loop unrolled, but need to profile and check if this provides actual performance improvements. The `apply_force_from_neighbor_gpu` iterates through all particles in the neighboring box, and calls the given `apply_force_gpu` kernel to apply forces from the neighbor particle to thisParticle.
 
-## Errors
+## GPU assignToBoxes
 
-Currently, not passing correctness check. Upon analysis of the GIF: ![1000_gpu_incorrect](outputs/1000_gpu.gif)
-
-One can see certain particles pass through others, not registering them as neighbors. Need to debug either:
-
-- box assignment
-- iterating through neighbor boxes and all particles from neighbor boxes
+The idea is to parallelize counting the number of particles per box, computation of the prefix sum, and assignment of `parts` indices to `particle_ids` through the GPU. Each thread will have access to the shared `gpu_boxCounts`, `gpu_prefixSums`, and `gpu_particle_ids` arrays. Atomic operations for adding in `gpu_boxCounts` will be necessary to prevent race conditions. Need to explore the best method for computing a prefixSum on the GPU: probably `thrust::exclusive_scan`.
 
 ## Useful Commands
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Sum of gpu_boxCounts: 999
 For some reason, not all the particles are being assigned to a box initially.
 
 [X] FIXED: atomicAdd ensures all particles are counted and added to boxCounts
-[ ] TODO: correctness check failing
+[X] FIXED: correctness check. Incorrectly changed memory size when copying gpu_particles to cpu particles.
 
 ## Useful Commands
 

--- a/gpu.cu
+++ b/gpu.cu
@@ -217,7 +217,7 @@ void assignToBoxes(particle_t* parts, int num_parts, int* gpu_boxCounts) {
 
     // Copy from parts (gpu_parts) to cpu_parts
     particle_t* cpu_parts = new particle_t[num_parts];
-    cudaMemcpy(cpu_parts, parts, particle_idMemSize, cudaMemcpyDeviceToHost);    
+    cudaMemcpy(cpu_parts, parts, num_parts * sizeof(particle_t), cudaMemcpyDeviceToHost);    
 
     // First pass: count particles in each box. Reset box counts from past iteration
     cudaMemset(gpu_boxCounts, 0, boxesMemSize);
@@ -225,11 +225,11 @@ void assignToBoxes(particle_t* parts, int num_parts, int* gpu_boxCounts) {
 
 
     //
-    // TEST countParticlesPerBox
-    // Use thrust to calculate the sum of all values in gpu_boxCounts
-    thrust::device_ptr<int> dev_ptr(gpu_boxCounts);
-    int totalParticles = thrust::reduce(dev_ptr, dev_ptr + totalBoxes, 0, thrust::plus<int>());
-    printf("Sum of gpu_boxCounts: %d\n", totalParticles);
+    // // TEST countParticlesPerBox
+    // // Use thrust to calculate the sum of all values in gpu_boxCounts
+    // thrust::device_ptr<int> dev_ptr(gpu_boxCounts);
+    // int totalParticles = thrust::reduce(dev_ptr, dev_ptr + totalBoxes, 0, thrust::plus<int>());
+    // printf("Sum of gpu_boxCounts: %d\n", totalParticles);
     
 
     // Wait for all threads to finish. Then copy gpu_boxCounts to CPU, use for computePrefixSum
@@ -237,8 +237,8 @@ void assignToBoxes(particle_t* parts, int num_parts, int* gpu_boxCounts) {
     cudaMemcpy(boxCounts, gpu_boxCounts, boxesMemSize, cudaMemcpyDeviceToHost);
 
     // // TEST cpu boxCounts sum
-    int totalParticlesCPU = std::accumulate(boxCounts, boxCounts + totalBoxes, 0);
-    printf("Sum of cpu boxCounts: %d\n", totalParticlesCPU);
+    // int totalParticlesCPU = std::accumulate(boxCounts, boxCounts + totalBoxes, 0);
+    // printf("Sum of cpu boxCounts: %d\n", totalParticlesCPU);
 
     // Compute starting index for each box in particle_idx from boxCounts
     computePrefixSum();

--- a/gpu.cu
+++ b/gpu.cu
@@ -164,7 +164,8 @@ __global__ void countParticlesPerBox(particle_t* gpu_parts, int num_parts, int* 
 
     int boxIndex = findBox(gpu_parts[tid], numBoxes1D, boxSize1D);
     // printf("cur parts idx: %i. boxIndex: %i. Coords: (%f, %f)\n", tid, boxIndex, gpu_parts[tid].x, gpu_parts[tid].y);
-    gpu_boxCounts[boxIndex]++;
+    // atomicAdd(&gpu_boxCounts[boxIndex], 1);
+    atomicAdd(gpu_boxCounts + boxIndex, 1);
 }
 
 // Iterates through boxCounts and computes a prefixSum
@@ -235,7 +236,7 @@ void assignToBoxes(particle_t* parts, int num_parts, int* gpu_boxCounts) {
     cudaDeviceSynchronize();
     cudaMemcpy(boxCounts, gpu_boxCounts, boxesMemSize, cudaMemcpyDeviceToHost);
 
-    // TEST cpu boxCounts sum
+    // // TEST cpu boxCounts sum
     int totalParticlesCPU = std::accumulate(boxCounts, boxCounts + totalBoxes, 0);
     printf("Sum of cpu boxCounts: %d\n", totalParticlesCPU);
 


### PR DESCRIPTION
# Highlights

- Implemented countParticlesPerBox as a CUDA kernel.
- Iterates across gpu_particles and stores # of particles per box in gpu_boxCounts
- Copy back gpu_boxCounts to cpu boxCounts and performs CPU calculations for prefixSum and particle_ids assignment
- Passes correctness check